### PR TITLE
Fix update of swapchain image context map

### DIFF
--- a/changes/conformance/pr.4.gh.OpenXR-CTS.md
+++ b/changes/conformance/pr.4.gh.OpenXR-CTS.md
@@ -1,0 +1,1 @@
+Fix: The D3D12, OpenGL and Vulcan graphics plugins sometimes did not update their swapchain image context maps due to rare key collisions.

--- a/src/conformance/framework/graphics_plugin_d3d12.cpp
+++ b/src/conformance/framework/graphics_plugin_d3d12.cpp
@@ -799,7 +799,7 @@ namespace Conformance
         // Map every swapchainImage base pointer to this context
         for (auto& base : bases) {
             derivedResult->imagePtrVector.push_back(base);
-            swapchainImageContextMap.emplace(std::make_pair(base, derivedResult.get()));
+            swapchainImageContextMap[base] = derivedResult.get();
         }
 
         // Cast our derived type to the caller-expected type.

--- a/src/conformance/framework/graphics_plugin_opengl.cpp
+++ b/src/conformance/framework/graphics_plugin_opengl.cpp
@@ -1093,7 +1093,7 @@ namespace Conformance
             // Set the generic vector of base pointers
             derivedResult->imagePtrVector.push_back(base);
             // Map every swapchainImage base pointer to this context
-            m_swapchainImageContextMap.emplace(std::make_pair(base, derivedResult));
+            m_swapchainImageContextMap[base] = derivedResult;
         }
 
         // Cast our derived type to the caller-expected type.

--- a/src/conformance/framework/graphics_plugin_vulkan.cpp
+++ b/src/conformance/framework/graphics_plugin_vulkan.cpp
@@ -2393,7 +2393,7 @@ namespace Conformance
             // Set the generic vector of base pointers
             derivedResult->imagePtrVector.push_back(base);
             // Map every swapchainImage base pointer to this context
-            m_swapchainImageContextMap.emplace(std::make_pair(base, derivedResult));
+            m_swapchainImageContextMap[base] = derivedResult;
         }
 
 #if defined(USE_MIRROR_WINDOW)


### PR DESCRIPTION
[std::map<Key,T,Compare,Allocator>::emplace](https://en.cppreference.com/w/cpp/container/map/emplace): "Inserts a new element into the container constructed in-place with the given args **if there is no element with the key in the container**."

The problem is that we use pointers as keys for the context map. If a memory block from a previous D3D12SwapchainImageStructs::imageVector is reused for a new D3D12SwapchainImageStructs::imageVector, this results in a key collision and the context map not being updated.

We stumbled upon it when we tested with D3D12, but the same mistake is made in the Vulkan and OpenGL graphics plugins too. 