### PR TITLE
Removed incorrect result string test

### DIFF
--- a/changes/conformance/pr.8.gh.OpenXR-CTS.md
+++ b/changes/conformance/pr.8.gh.OpenXR-CTS.md
@@ -1,0 +1,1 @@
+Fixed test: Removed extra check that would fail if the CTS was compiled against a version of openxr.h that included extensions that added results that were newer than the results present in the version of openxr.h that the runtime was compiled against.

--- a/src/conformance/conformance_test/test_xrResultToString.cpp
+++ b/src/conformance/conformance_test/test_xrResultToString.cpp
@@ -47,7 +47,6 @@ namespace Conformance
             REQUIRE(result == XR_SUCCESS);
             bool allowGeneratedName = false;
             uint64_t ext_num = 0;
-            CHECK(std::string(buffer) == value.second);
             if (std::abs(value.first) >= 1000000000) {
                 // This is an extension
                 ext_num = (std::abs(value.first) - 1000000000) / 1000;


### PR DESCRIPTION
This CHECK is handled by more complex code right below it. That more complex code also handles the case where the runtime only has a subset of the enums in the header as of whenever the conformance tests were built.