### PR TITLE
Fixed conformance failures on runtimes where x and y components can have different last changed times

### DIFF
--- a/changes/conformance/pr.9.gh.OpenXR-CTS.md
+++ b/changes/conformance/pr.9.gh.OpenXR-CTS.md
@@ -1,0 +1,1 @@
+Fixed test: Fixed conformance failures on runtimes where x and y components can have different last changed times

--- a/src/conformance/conformance_test/test_actions.cpp
+++ b/src/conformance/conformance_test/test_actions.cpp
@@ -2151,13 +2151,14 @@ namespace Conformance
                                 REQUIRE(floatState.isActive);
                                 REQUIRE(floatState.currentState == vectorState.currentState.x);
                                 ++combinedFloatCount;
+                                XrTime xTime = 0;
                                 if (!largestFloatState.isActive ||
                                     (std::fabs(largestFloatState.currentState) < std::fabs(floatState.currentState))) {
                                     largestFloatState = floatState;
                                 }
                                 if (floatState.changedSinceLastSync) {
                                     REQUIRE(floatState.changedSinceLastSync == vectorState.changedSinceLastSync);
-                                    REQUIRE(floatState.lastChangeTime == vectorState.lastChangeTime);
+                                    xTime = floatState.lastChangeTime;
                                     ++xyChanges;
                                 }
                                 if (!vectorState.changedSinceLastSync) {
@@ -2170,17 +2171,23 @@ namespace Conformance
                                 REQUIRE(floatState.isActive);
                                 REQUIRE(floatState.currentState == vectorState.currentState.y);
                                 ++combinedFloatCount;
+                                XrTime yTime = 0;
                                 if (!largestFloatState.isActive ||
                                     (std::fabs(largestFloatState.currentState) < std::fabs(floatState.currentState))) {
                                     largestFloatState = floatState;
                                 }
                                 if (floatState.changedSinceLastSync) {
                                     REQUIRE(floatState.changedSinceLastSync == vectorState.changedSinceLastSync);
-                                    REQUIRE(floatState.lastChangeTime == vectorState.lastChangeTime);
+                                    yTime = floatState.lastChangeTime;
                                     ++xyChanges;
                                 }
                                 if (!vectorState.changedSinceLastSync) {
                                     REQUIRE(floatState.changedSinceLastSync == XR_FALSE);
+                                }
+
+                                if ( xTime && yTime ) {
+                                    XrTime expectedTime = xTime > yTime ? xTime : yTime;
+                                    REQUIRE( expectedTime == vectorState.lastChangeTime );
                                 }
 
                                 if (vectorState.changedSinceLastSync) {


### PR DESCRIPTION
Test that vector2 actions get the max of the two component lastChangedTime values instead of assuming that they will be the same. These component updates are provided by third party drivers in SteamVR, so there's no guarantee they will update at the same time.