### PR TITLE
Fixed image barriers to apply to arraySlice

### DIFF
--- a/changes/conformance/pr.11.gh.OpenXR-CTS.md
+++ b/changes/conformance/pr.11.gh.OpenXR-CTS.md
@@ -1,0 +1,1 @@
+Fix: `CopyRGBAImage` was using the wrong array slice when setting image barriers. This broke the "Subimage Tests" case on some hardware/drivers.

--- a/src/conformance/framework/graphics_plugin_vulkan.cpp
+++ b/src/conformance/framework/graphics_plugin_vulkan.cpp
@@ -2478,7 +2478,7 @@ namespace Conformance
         imgBarrier.srcQueueFamilyIndex = m_queueFamilyIndex;
         imgBarrier.dstQueueFamilyIndex = m_queueFamilyIndex;
         imgBarrier.image = swapchainImageVk->image;
-        imgBarrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        imgBarrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, arraySlice, 1};
         vkCmdPipelineBarrier(m_cmdBuffer.buf, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1,
                              &imgBarrier);
 
@@ -2498,7 +2498,7 @@ namespace Conformance
         imgBarrier.srcQueueFamilyIndex = m_queueFamilyIndex;
         imgBarrier.dstQueueFamilyIndex = m_queueFamilyIndex;
         imgBarrier.image = swapchainImageVk->image;
-        imgBarrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        imgBarrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, arraySlice, 1};
         vkCmdPipelineBarrier(m_cmdBuffer.buf, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, nullptr, 0,
                              nullptr, 1, &imgBarrier);
 


### PR DESCRIPTION
These barriers on the destination side were always on slice 0. For the "Subimage Tests" case, the test writes static data to both slice 0 and slice 1. When we wrote them to slice 1, it transitioned the layouts on since 0 instead. Drivers are allowed to clear in this case, and my particular driver happily did.