### PR TITLE
Forced the test to wait for the GPU after rendering

### DIFF
--- a/changes/conformance/pr.12.gh.OpenXR-CTS.md
+++ b/changes/conformance/pr.12.gh.OpenXR-CTS.md
@@ -1,0 +1,1 @@
+Fix: Added `WaitForGpu` call at the end of `RenderView` in `D3D12GraphicsPlugin`. Without this the array and wide swapchain tests failed on some hardware/driver versions.

--- a/src/conformance/framework/graphics_plugin_d3d12.cpp
+++ b/src/conformance/framework/graphics_plugin_d3d12.cpp
@@ -1005,6 +1005,7 @@ namespace Conformance
 
             XRC_CHECK_THROW_HRCMD(cmdList->Close());
             CHECK(ExecuteCommandList(cmdList.Get()));
+            WaitForGpu();
         }
     }
 

--- a/src/conformance/framework/graphics_plugin_d3d12.cpp
+++ b/src/conformance/framework/graphics_plugin_d3d12.cpp
@@ -1005,6 +1005,11 @@ namespace Conformance
 
             XRC_CHECK_THROW_HRCMD(cmdList->Close());
             CHECK(ExecuteCommandList(cmdList.Get()));
+
+            // TODO: Track down exactly why this wait is needed. 
+            // On some drivers and/or hardware the test is generating the same image for the left and right eye,
+            // and generating images that fail the interactive tests. This did not seem to be the case several
+            // months ago, so it likely a driver change that flipped a race condition the other direction.
             WaitForGpu();
         }
     }


### PR DESCRIPTION
Not waiting was causing some bad behavior in the array and wide swapchain tests on D3D12. I think this was caused by the textures being destroyed and recreated on subsequent views, but I'm not sure. 

This is actually @brycehutchings 's fix. I'm just making a PR for it.