### PR TITLE
Action test fixes

### DIFF
--- a/changes/conformance/pr.14.gh.OpenXR-CTS.md
+++ b/changes/conformance/pr.14.gh.OpenXR-CTS.md
@@ -1,0 +1,2 @@
+Fix: The test assumed that X and Y components of a vector2 action would have exactly the same timestamp. Changed that to check that the vector2 action would have the most recent of those two timestamps instead.
+Fix: The test checked for "float value == X" and then checked for its binary thresholded value after a subsequent call to xrSyncActions. Changed the test so both checks happen in the same input frame.

--- a/src/conformance/conformance_test/test_actions.cpp
+++ b/src/conformance/conformance_test/test_actions.cpp
@@ -2185,9 +2185,9 @@ namespace Conformance
                                     REQUIRE(floatState.changedSinceLastSync == XR_FALSE);
                                 }
 
-                                if ( xTime && yTime ) {
+                                if (xTime && yTime) {
                                     XrTime expectedTime = xTime > yTime ? xTime : yTime;
-                                    REQUIRE( expectedTime == vectorState.lastChangeTime );
+                                    REQUIRE(expectedTime == vectorState.lastChangeTime);
                                 }
 
                                 if (vectorState.changedSinceLastSync) {
@@ -2427,26 +2427,20 @@ namespace Conformance
                     XrActionStateGetInfo getInfo{XR_TYPE_ACTION_STATE_GET_INFO};
                     getInfo.action = booleanToFloatActionData.Action;
 
-                    inputDevice->SetButtonStateFloat(inputSourcePath, 0.0f, cEpsilon);
-
-                    actionLayerManager.SyncActionsUntilFocusWithMessage(syncInfo);
+                    inputDevice->SetButtonStateFloat(inputSourcePath, 0.0f, cEpsilon, false, actionSet );
 
                     REQUIRE_RESULT(xrGetActionStateBoolean(compositionHelper.GetSession(), &getInfo, &booleanState), XR_SUCCESS);
                     REQUIRE(booleanState.isActive);
                     REQUIRE_FALSE(booleanState.currentState);
 
-                    inputDevice->SetButtonStateFloat(inputSourcePath, 1.0f, cEpsilon);
-
-                    actionLayerManager.SyncActionsUntilFocusWithMessage(syncInfo);
+                    inputDevice->SetButtonStateFloat(inputSourcePath, 1.0f, cEpsilon, false, actionSet );
 
                     REQUIRE_RESULT(xrGetActionStateBoolean(compositionHelper.GetSession(), &getInfo, &booleanState), XR_SUCCESS);
                     REQUIRE(booleanState.isActive);
                     REQUIRE(booleanState.currentState);
                     REQUIRE(booleanState.lastChangeTime > 0);
 
-                    inputDevice->SetButtonStateFloat(inputSourcePath, 0.0f, cEpsilon);
-
-                    actionLayerManager.SyncActionsUntilFocusWithMessage(syncInfo);
+                    inputDevice->SetButtonStateFloat(inputSourcePath, 0.0f, cEpsilon, false, actionSet );
 
                     REQUIRE_RESULT(xrGetActionStateBoolean(compositionHelper.GetSession(), &getInfo, &booleanState), XR_SUCCESS);
                     REQUIRE(booleanState.isActive);
@@ -2461,26 +2455,20 @@ namespace Conformance
                     XrActionStateGetInfo getInfo{XR_TYPE_ACTION_STATE_GET_INFO};
                     getInfo.action = floatToBooleanActionData.Action;
 
-                    inputDevice->SetButtonStateBool(inputSourcePath, false);
-
-                    actionLayerManager.SyncActionsUntilFocusWithMessage(syncInfo);
+                    inputDevice->SetButtonStateBool(inputSourcePath, false, false, actionSet );
 
                     REQUIRE_RESULT(xrGetActionStateFloat(compositionHelper.GetSession(), &getInfo, &floatState), XR_SUCCESS);
                     REQUIRE(floatState.isActive);
                     REQUIRE(floatState.currentState == Approx(0.0f).margin(cLargeEpsilon));
 
-                    inputDevice->SetButtonStateBool(inputSourcePath, true);
-
-                    actionLayerManager.SyncActionsUntilFocusWithMessage(syncInfo);
+                    inputDevice->SetButtonStateBool(inputSourcePath, true, false, actionSet );
 
                     REQUIRE_RESULT(xrGetActionStateFloat(compositionHelper.GetSession(), &getInfo, &floatState), XR_SUCCESS);
                     REQUIRE(floatState.isActive);
                     REQUIRE(floatState.currentState == Approx(1.0f).margin(cLargeEpsilon));
                     REQUIRE(floatState.lastChangeTime > 0);
 
-                    inputDevice->SetButtonStateBool(inputSourcePath, false);
-
-                    actionLayerManager.SyncActionsUntilFocusWithMessage(syncInfo);
+                    inputDevice->SetButtonStateBool(inputSourcePath, false, false, actionSet );
 
                     REQUIRE_RESULT(xrGetActionStateFloat(compositionHelper.GetSession(), &getInfo, &floatState), XR_SUCCESS);
                     REQUIRE(floatState.isActive);

--- a/src/conformance/framework/input_testinputdevice.cpp
+++ b/src/conformance/framework/input_testinputdevice.cpp
@@ -16,6 +16,7 @@
 
 #include <chrono>
 #include <thread>
+#include <array>
 
 #include <openxr/openxr.h>
 
@@ -181,7 +182,7 @@ namespace Conformance
             m_messageDisplay->DisplayMessage("");
         }
 
-        void SetButtonStateBool(XrPath button, bool state, bool skipInteraction) override
+        void SetButtonStateBool(XrPath button, bool state, bool skipInteraction, XrActionSet extraActionSet = XR_NULL_HANDLE ) override
         {
             if (m_conformanceAutomationExtensionEnabled) {
                 PFN_xrSetInputDeviceStateBoolEXT xrSetInputDeviceStateBoolEXT{nullptr};
@@ -208,10 +209,10 @@ namespace Conformance
             XrAction actionToDetect = m_actionMap.at(button);
 
             auto GetButtonState = [&](XrAction action) -> bool {
-                XrActiveActionSet activeActionSet{m_actionSet};
+                XrActiveActionSet activeActionSet[] = { {m_actionSet}, { extraActionSet } };
                 XrActionsSyncInfo syncInfo{XR_TYPE_ACTIONS_SYNC_INFO};
-                syncInfo.countActiveActionSets = 1;
-                syncInfo.activeActionSets = &activeActionSet;
+                syncInfo.countActiveActionSets = extraActionSet == XR_NULL_HANDLE ? 1 : 2;
+                syncInfo.activeActionSets = activeActionSet;
                 const XrResult syncRes = xrSyncActions(m_session, &syncInfo);
                 if (syncRes == XR_SESSION_NOT_FOCUSED) {
                     return false;
@@ -238,7 +239,7 @@ namespace Conformance
             m_messageDisplay->DisplayMessage("");
         }
 
-        void SetButtonStateFloat(XrPath button, float state, float epsilon, bool skipInteraction = false) override
+        void SetButtonStateFloat(XrPath button, float state, float epsilon, bool skipInteraction = false, XrActionSet extraActionSet = XR_NULL_HANDLE ) override
         {
             if (m_conformanceAutomationExtensionEnabled) {
                 PFN_xrSetInputDeviceStateFloatEXT xrSetInputDeviceStateFloatEXT{nullptr};
@@ -264,10 +265,10 @@ namespace Conformance
             XrAction actionToDetect = m_actionMap.at(button);
 
             auto FloatStateWithinEpsilon = [&](XrAction action, float target, float epsilon) -> bool {
-                XrActiveActionSet activeActionSet{m_actionSet};
+                XrActiveActionSet activeActionSet[] = {{m_actionSet}, {extraActionSet}};
                 XrActionsSyncInfo syncInfo{XR_TYPE_ACTIONS_SYNC_INFO};
-                syncInfo.countActiveActionSets = 1;
-                syncInfo.activeActionSets = &activeActionSet;
+                syncInfo.countActiveActionSets = extraActionSet == XR_NULL_HANDLE ? 1 : 2;
+                syncInfo.activeActionSets = activeActionSet;
                 const XrResult syncRes = xrSyncActions(m_session, &syncInfo);
                 if (syncRes == XR_SESSION_NOT_FOCUSED) {
                     return false;
@@ -297,7 +298,7 @@ namespace Conformance
             m_messageDisplay->DisplayMessage("");
         }
 
-        void SetButtonStateVector2(XrPath button, XrVector2f state, float epsilon, bool skipInteraction = false) override
+        void SetButtonStateVector2(XrPath button, XrVector2f state, float epsilon, bool skipInteraction = false, XrActionSet extraActionSet = XR_NULL_HANDLE ) override
         {
             if (m_conformanceAutomationExtensionEnabled) {
                 PFN_xrSetInputDeviceStateVector2fEXT xrSetInputDeviceStateVector2fEXT{nullptr};
@@ -324,10 +325,10 @@ namespace Conformance
             XrAction actionToDetect = m_actionMap.at(button);
 
             auto VectorStateWithinEpsilon = [&](XrAction action, XrVector2f target, float epsilon) -> bool {
-                XrActiveActionSet activeActionSet{m_actionSet};
+                XrActiveActionSet activeActionSet[] = {{m_actionSet}, {extraActionSet}};
                 XrActionsSyncInfo syncInfo{XR_TYPE_ACTIONS_SYNC_INFO};
-                syncInfo.countActiveActionSets = 1;
-                syncInfo.activeActionSets = &activeActionSet;
+                syncInfo.countActiveActionSets = extraActionSet == XR_NULL_HANDLE ? 1 : 2;
+                syncInfo.activeActionSets = activeActionSet;
                 const XrResult syncRes = xrSyncActions(m_session, &syncInfo);
                 if (syncRes == XR_SESSION_NOT_FOCUSED) {
                     return false;

--- a/src/conformance/framework/input_testinputdevice.h
+++ b/src/conformance/framework/input_testinputdevice.h
@@ -318,9 +318,9 @@ namespace Conformance
         virtual XrPath TopLevelPath() const = 0;
 
         virtual void SetDeviceActive(bool state, bool skipInteraction = false) = 0;
-        virtual void SetButtonStateBool(XrPath button, bool state, bool skipInteraction = false) = 0;
-        virtual void SetButtonStateFloat(XrPath button, float state, float epsilon = 0, bool skipInteraction = false) = 0;
-        virtual void SetButtonStateVector2(XrPath button, XrVector2f state, float epsilon = 0, bool skipInteraction = false) = 0;
+        virtual void SetButtonStateBool(XrPath button, bool state, bool skipInteraction = false, XrActionSet extraActionSet = XR_NULL_HANDLE ) = 0;
+        virtual void SetButtonStateFloat(XrPath button, float state, float epsilon = 0, bool skipInteraction = false, XrActionSet extraActionSet = XR_NULL_HANDLE ) = 0;
+        virtual void SetButtonStateVector2(XrPath button, XrVector2f state, float epsilon = 0, bool skipInteraction = false, XrActionSet extraActionSet = XR_NULL_HANDLE ) = 0;
     };
 
     struct ITestMessageDisplay


### PR DESCRIPTION
* Fixed test and check happening from two different input frames
The user is prompted to get a float input to a particular value. xrSyncActions is called repeatedly to test to see if that has happened. Then xrSyncActions is called one last time to see if the float value was coerced to the correct boolean value in another action. For very unstable float values (like x=1 on a capsule-shaped trackpad) or slow-running implementation the float value could have changed between those two frames, and the test would fail.

This change piggybacks the bool=Y test into the same xrSyncActions call as the float=X test

* Fixed X and Y times not exactly matching XY time

The spec guarantees that action update times not change until the next xrSyncActions call, but doesn't require that the X and Y components have the same timestamp as the combined vector XY time. In SteamVR these components are updated asynchronously by drivers, so they may not match.

The test will now make sure the XY time is the most recent of its two components.