### PR TITLE
Lower the amount of time that the renderer blocks

### DIFF
--- a/changes/conformance/pr.18.gh.OpenXR-CTS.md
+++ b/changes/conformance/pr.18.gh.OpenXR-CTS.md
@@ -1,0 +1,3 @@
+Lower the amount of time that the renderer blocks. The CTS is not a highly
+optimized application and due to thread scheduling and extra GPU waits 90% CPU
+wait makes it fairly tight to fit everything inside of a single display period.

--- a/src/conformance/conformance_test/test_FrameSubmission.cpp
+++ b/src/conformance/conformance_test/test_FrameSubmission.cpp
@@ -240,7 +240,7 @@ namespace Conformance
         constexpr int warmupFrameCount = 180;           // Prewarm the frame loop for this many frames.
         constexpr int testFrameCount = 200;             // Average this many frames for analysis.
         constexpr double waitBlockPercentage = 0.90;    // Block for 90% of the display period on waitframe thread.
-        constexpr double renderBlockPercentage = 0.90;  // Block for 90% of the display period on render thread.
+        constexpr double renderBlockPercentage = 0.70;  // Block for 70% of the display period on render thread.
 
         std::queue<XrFrameState> queuedFramesForRender;
         std::mutex displayMutex;


### PR DESCRIPTION
The CTS is not a highly optimized application and due to thread scheduling
and extra GPU waits 90% CPU wait makes it fairly tight to fit everything
inside of a single display period.