### PR TITLE
Make scenario tests visible

### DIFF
--- a/changes/conformance/mr.21.gh
+++ b/changes/conformance/mr.21.gh
@@ -1,0 +1,1 @@
+Fix: Make "Grip and Aim Pose" and "Projection Mutable Field-of-View" tests visible.

--- a/src/conformance/conformance_test/test_ActionPoses.cpp
+++ b/src/conformance/conformance_test/test_ActionPoses.cpp
@@ -36,7 +36,7 @@ namespace Conformance
     constexpr XrVector3f Up{0, 1, 0};
 
     // Purpose: Ensure that the action space for grip can be used for a grippable object, in this case a sword, and the action space for aim can be used for comfortable aiming.
-    TEST_CASE("Grip and Aim Pose", "[.][scenario][interactive]")
+    TEST_CASE("Grip and Aim Pose", "[scenario][interactive]")
     {
         const char* exampleImage = "grip_and_aim_pose.png";
         const char* instructions =

--- a/src/conformance/conformance_test/test_LayerComposition.cpp
+++ b/src/conformance/conformance_test/test_LayerComposition.cpp
@@ -751,7 +751,7 @@ namespace Conformance
         RenderLoop(compositionHelper.GetSession(), updateLayers).Loop();
     }
 
-    TEST_CASE("Projection Mutable Field-of-View", "[.][composition][interactive]")
+    TEST_CASE("Projection Mutable Field-of-View", "[composition][interactive]")
     {
         CompositionHelper compositionHelper("Projection Mutable Field-of-View");
         InteractiveLayerManager interactiveLayerManager(compositionHelper, "projection_mutable.png",


### PR DESCRIPTION
It seems two interactive tests slipped by are are still marked as hidden with the catch2 "[.]" tag. Thankfully the tests will still run when running the CTS following the instructions in the readme.md file.