### PR TITLE
Fix read access violation for d3d12 device on shutdown

### DIFF
--- a/src/conformance/framework/graphics_plugin_d3d12.cpp
+++ b/src/conformance/framework/graphics_plugin_d3d12.cpp
@@ -495,6 +495,13 @@ namespace Conformance
     {
         graphicsBinding = XrGraphicsBindingD3D12KHR{XR_TYPE_GRAPHICS_BINDING_D3D12_KHR};
         d3d12CmdQueue.Reset();
+        fence.Reset();
+        rootSignature.Reset();
+        pipelineStates.clear();
+        cubeVertexBuffer.Reset();
+        cubeIndexBuffer.Reset();
+        rtvHeap.Reset();
+        dsvHeap.Reset();
         d3d12Device.Reset();
         swapchainImageContextMap.clear();
         lastSwapchainImage = nullptr;


### PR DESCRIPTION
Fix read access violation for d3d12 device on shutdown due to freeing device prior to freeing resources.