### PR TITLE
Fix mutable fov inversion

### DIFF
--- a/changes/conformance/mr.23.gh
+++ b/changes/conformance/mr.23.gh
@@ -1,0 +1,1 @@
+Fix: Fix mutable field-of-view X and Y flip for non-symmetrical FOVs.

--- a/src/conformance/conformance_test/test_LayerComposition.cpp
+++ b/src/conformance/conformance_test/test_LayerComposition.cpp
@@ -826,13 +826,13 @@ namespace Conformance
                             XrQuaternionf_Multiply(&rolled.pose.orientation, &roll180, &views[view].pose.orientation);
                             GetGlobalData().graphicsPlugin->RenderView(rolled, swapchainImage, format, cubes);
 
-                            // After rendering, report a flipped FOV on X and Y without the 180 degree roll, which is effectively
-                            // has the same effect. This switcheroo is necessary since rendering with flipped FOV will result in
+                            // After rendering, report a flipped FOV on X and Y without the 180 degree roll, which has the same effect.
+                            // the same effect. This switcheroo is necessary since rendering with flipped FOV will result in
                             // an inverted winding causing normally hidden triangles to be visible and visible triangles to be hidden.
-                            std::swap(const_cast<float&>(projLayer->views[view].fov.angleUp),
-                                      const_cast<float&>(projLayer->views[view].fov.angleDown));
-                            std::swap(const_cast<float&>(projLayer->views[view].fov.angleLeft),
-                                      const_cast<float&>(projLayer->views[view].fov.angleRight));
+                            const_cast<float&>(projLayer->views[view].fov.angleUp) = -projLayer->views[view].fov.angleUp;
+                            const_cast<float&>(projLayer->views[view].fov.angleDown) = -projLayer->views[view].fov.angleDown;
+                            const_cast<float&>(projLayer->views[view].fov.angleLeft) = -projLayer->views[view].fov.angleLeft;
+                            const_cast<float&>(projLayer->views[view].fov.angleRight) = -projLayer->views[view].fov.angleRight;
                         }
                     });
 

--- a/src/conformance/conformance_test/test_LayerComposition.cpp
+++ b/src/conformance/conformance_test/test_LayerComposition.cpp
@@ -826,9 +826,9 @@ namespace Conformance
                             XrQuaternionf_Multiply(&rolled.pose.orientation, &roll180, &views[view].pose.orientation);
                             GetGlobalData().graphicsPlugin->RenderView(rolled, swapchainImage, format, cubes);
 
-                            // After rendering, report a flipped FOV on X and Y without the 180 degree roll, which has the same effect.
-                            // the same effect. This switcheroo is necessary since rendering with flipped FOV will result in
-                            // an inverted winding causing normally hidden triangles to be visible and visible triangles to be hidden.
+                            // After rendering, report a flipped FOV on X and Y without the 180 degree roll, which has the same
+                            // effect. This switcheroo is necessary since rendering with flipped FOV will result in an inverted
+                            // winding causing normally hidden triangles to be visible and visible triangles to be hidden.
                             const_cast<float&>(projLayer->views[view].fov.angleUp) = -projLayer->views[view].fov.angleUp;
                             const_cast<float&>(projLayer->views[view].fov.angleDown) = -projLayer->views[view].fov.angleDown;
                             const_cast<float&>(projLayer->views[view].fov.angleLeft) = -projLayer->views[view].fov.angleLeft;


### PR DESCRIPTION
Swapping the left/right and up/down angles was the wrong way to flip the contents. A runtime should see if left>right and up>down and if so compose the swapchain image flipped with the negated (restored) FOV, so if a runtime wasn't using symmetric FOV this test would have given incorrect results.