### PR TITLE
Changes to make some kinds of layer comp flag failures more obvious

### DIFF
--- a/changes/conformance/mr.25.gh
+++ b/changes/conformance/mr.25.gh
@@ -1,0 +1,1 @@
+Fix: Make some failures caused by missing layer flag implementations more obvious.

--- a/src/conformance/conformance_test/test_LayerComposition.cpp
+++ b/src/conformance/conformance_test/test_LayerComposition.cpp
@@ -356,7 +356,7 @@ namespace Conformance
 
             const XrSwapchain answerSwapchain = compositionHelper.CreateStaticSwapchainImage(blueGradientOverGreen);
             XrCompositionLayerQuad *truthQuad =
-                compositionHelper.CreateQuadLayer( answerSwapchain, viewSpace, 1.0f, XrPosef { Quat::Identity, {0, 0, QuadZ} } ));
+                compositionHelper.CreateQuadLayer( answerSwapchain, viewSpace, 1.0f, XrPosef { Quat::Identity, {0, 0, QuadZ} });
             truthQuad->layerFlags |= XR_COMPOSITION_LAYER_UNPREMULTIPLIED_ALPHA_BIT;
             interactiveLayerManager.AddLayer( truthQuad );
         }

--- a/src/conformance/conformance_test/test_LayerComposition.cpp
+++ b/src/conformance/conformance_test/test_LayerComposition.cpp
@@ -277,9 +277,9 @@ namespace Conformance
         const XrQuaternionf redRot = Quat::FromAxisAngle({0, 1, 0}, Math::DegToRad(180));
         interactiveLayerManager.AddLayer(compositionHelper.CreateQuadLayer(redSwapchain, viewSpace, 1.0f, XrPosef{redRot, {0, 0, -1}}));
 
-        RenderLoop(compositionHelper.GetSession(),
-                   [&](const XrFrameState& frameState) { return interactiveLayerManager.EndFrame(frameState); })
-            .Loop();
+        RenderLoop(compositionHelper.GetSession(), [&](const XrFrameState& frameState) {
+            return interactiveLayerManager.EndFrame(frameState);
+        }).Loop();
     }
 
     // Purpose: Verify order of transforms by exercising the two ways poses can be specified:
@@ -325,9 +325,9 @@ namespace Conformance
             interactiveLayerManager.AddLayer(quad2);
         }
 
-        RenderLoop(compositionHelper.GetSession(),
-                   [&](const XrFrameState& frameState) { return interactiveLayerManager.EndFrame(frameState); })
-            .Loop();
+        RenderLoop(compositionHelper.GetSession(), [&](const XrFrameState& frameState) {
+            return interactiveLayerManager.EndFrame(frameState);
+        }).Loop();
     }
 
     // Purpose: Validates alpha blending (both premultiplied and unpremultiplied).
@@ -355,10 +355,10 @@ namespace Conformance
             }
 
             const XrSwapchain answerSwapchain = compositionHelper.CreateStaticSwapchainImage(blueGradientOverGreen);
-            XrCompositionLayerQuad *truthQuad =
-                compositionHelper.CreateQuadLayer( answerSwapchain, viewSpace, 1.0f, XrPosef { Quat::Identity, {0, 0, QuadZ} });
+            XrCompositionLayerQuad* truthQuad =
+                compositionHelper.CreateQuadLayer(answerSwapchain, viewSpace, 1.0f, XrPosef{Quat::Identity, {0, 0, QuadZ}});
             truthQuad->layerFlags |= XR_COMPOSITION_LAYER_UNPREMULTIPLIED_ALPHA_BIT;
-            interactiveLayerManager.AddLayer( truthQuad );
+            interactiveLayerManager.AddLayer(truthQuad);
         }
 
         auto createGradientTest = [&](bool premultiplied, float x, float y) {
@@ -366,7 +366,7 @@ namespace Conformance
             {
                 const XrSwapchain greenSwapchain = compositionHelper.CreateStaticSwapchainSolidColor(Colors::GreenZeroAlpha);
                 XrCompositionLayerQuad* greenQuad =
-                    compositionHelper.CreateQuadLayer( greenSwapchain, viewSpace, 1.0f, XrPosef { Quat::Identity, {x, y, QuadZ} } );
+                    compositionHelper.CreateQuadLayer(greenSwapchain, viewSpace, 1.0f, XrPosef{Quat::Identity, {x, y, QuadZ}});
                 greenQuad->layerFlags |= XR_COMPOSITION_LAYER_UNPREMULTIPLIED_ALPHA_BIT;
                 interactiveLayerManager.AddLayer(greenQuad);
             }
@@ -399,9 +399,9 @@ namespace Conformance
         createGradientTest(true, -1.02f, 0);  // Test premultiplied (left of center "answer")
         createGradientTest(false, 1.02f, 0);  // Test unpremultiplied (right of center "answer")
 
-        RenderLoop(compositionHelper.GetSession(),
-                   [&](const XrFrameState& frameState) { return interactiveLayerManager.EndFrame(frameState); })
-            .Loop();
+        RenderLoop(compositionHelper.GetSession(), [&](const XrFrameState& frameState) {
+            return interactiveLayerManager.EndFrame(frameState);
+        }).Loop();
     }
 
     // Purpose: Validate eye visibility flags.
@@ -428,9 +428,9 @@ namespace Conformance
         quad2->eyeVisibility = XR_EYE_VISIBILITY_RIGHT;
         interactiveLayerManager.AddLayer(quad2);
 
-        RenderLoop(compositionHelper.GetSession(),
-                   [&](const XrFrameState& frameState) { return interactiveLayerManager.EndFrame(frameState); })
-            .Loop();
+        RenderLoop(compositionHelper.GetSession(), [&](const XrFrameState& frameState) {
+            return interactiveLayerManager.EndFrame(frameState);
+        }).Loop();
     }
 
     TEST_CASE("Subimage Tests", "[composition][interactive]")
@@ -496,9 +496,9 @@ namespace Conformance
             }
         });
 
-        RenderLoop(compositionHelper.GetSession(),
-                   [&](const XrFrameState& frameState) { return interactiveLayerManager.EndFrame(frameState); })
-            .Loop();
+        RenderLoop(compositionHelper.GetSession(), [&](const XrFrameState& frameState) {
+            return interactiveLayerManager.EndFrame(frameState);
+        }).Loop();
     }
 
     TEST_CASE("Projection Array Swapchain", "[composition][interactive]")

--- a/src/conformance/conformance_test/test_LayerComposition.cpp
+++ b/src/conformance/conformance_test/test_LayerComposition.cpp
@@ -43,6 +43,7 @@ namespace
     {
         constexpr XrColor4f Red = {1, 0, 0, 1};
         constexpr XrColor4f Green = {0, 1, 0, 1};
+        constexpr XrColor4f GreenZeroAlpha = {0, 1, 0, 0};
         constexpr XrColor4f Blue = {0, 0, 1, 1};
         constexpr XrColor4f Purple = {1, 0, 1, 1};
         constexpr XrColor4f Yellow = {1, 1, 0, 1};
@@ -349,21 +350,25 @@ namespace Conformance
                 const float t = y / 255.0f;
                 const XrColor4f dst = Colors::Green;
                 const XrColor4f src{0, 0, t, t};
-                const XrColor4f blended{dst.r * (1 - src.a) + src.r, dst.g * (1 - src.a) + src.g, dst.b * (1 - src.a) + src.b, 1};
+                const XrColor4f blended{dst.r * (1 - src.a) + src.r, dst.g * (1 - src.a) + src.g, dst.b * (1 - src.a) + src.b, 0};
                 blueGradientOverGreen.DrawRect(0, y, blueGradientOverGreen.width, 1, blended);
             }
 
             const XrSwapchain answerSwapchain = compositionHelper.CreateStaticSwapchainImage(blueGradientOverGreen);
-            interactiveLayerManager.AddLayer(
-                compositionHelper.CreateQuadLayer(answerSwapchain, viewSpace, 1.0f, XrPosef{Quat::Identity, {0, 0, QuadZ}}));
+            XrCompositionLayerQuad *truthQuad =
+                compositionHelper.CreateQuadLayer( answerSwapchain, viewSpace, 1.0f, XrPosef { Quat::Identity, {0, 0, QuadZ} } ));
+            truthQuad->layerFlags |= XR_COMPOSITION_LAYER_UNPREMULTIPLIED_ALPHA_BIT;
+            interactiveLayerManager.AddLayer( truthQuad );
         }
 
         auto createGradientTest = [&](bool premultiplied, float x, float y) {
             // A solid green quad layer will be composited under a blue gradient.
             {
-                const XrSwapchain greenSwapchain = compositionHelper.CreateStaticSwapchainSolidColor(Colors::Green);
-                interactiveLayerManager.AddLayer(
-                    compositionHelper.CreateQuadLayer(greenSwapchain, viewSpace, 1.0f, XrPosef{Quat::Identity, {x, y, QuadZ}}));
+                const XrSwapchain greenSwapchain = compositionHelper.CreateStaticSwapchainSolidColor(Colors::GreenZeroAlpha);
+                XrCompositionLayerQuad* greenQuad =
+                    compositionHelper.CreateQuadLayer( greenSwapchain, viewSpace, 1.0f, XrPosef { Quat::Identity, {x, y, QuadZ} } );
+                greenQuad->layerFlags |= XR_COMPOSITION_LAYER_UNPREMULTIPLIED_ALPHA_BIT;
+                interactiveLayerManager.AddLayer(greenQuad);
             }
 
             // Create gradient of blue lines from 0.0 to 1.0.


### PR DESCRIPTION
The background alpha is on the green layers and the example quad are 0 now. Those quad layers don't include the "use texture alpha" flag, so they should draw in exactly the same way. If the implementation is actually using the alpha from the texture, they will be invisible, which will be obviously wrong in the output.

Added the "not premult" flag to those quads too. SteamVR doesn't currently pay any attention to the "use alpha" flag, but it does monitor the premult flag.  A fully conformant runtime should ignore the premult flag if the other one isn't set too, so this should not affect those.