### PR TITLE
Don't submit a projection layer if the swapchain is never acquired

### DIFF
--- a/changes/conformance/pr.27.gh.OpenXR-CTS.md
+++ b/changes/conformance/pr.27.gh.OpenXR-CTS.md
@@ -1,0 +1,1 @@
+Fix: Avoid submitting projection layers when the referenced swapchain hasn't been used yet.

--- a/src/conformance/conformance_test/test_FrameSubmission.cpp
+++ b/src/conformance/conformance_test/test_FrameSubmission.cpp
@@ -330,8 +330,10 @@ namespace Conformance
 
             Stopwatch sw(true);
 
-            simpleProjectionLayerHelper.UpdateProjectionLayer(frameState);
-            std::vector<XrCompositionLayerBaseHeader*> layers{simpleProjectionLayerHelper.GetProjectionLayer()};
+            std::vector<XrCompositionLayerBaseHeader*> layers;
+            if (XrCompositionLayerBaseHeader* projLayer = simpleProjectionLayerHelper.TryGetUpdatedProjectionLayer(frameState)) {
+                layers.push_back(projLayer);
+            }
 
             // Mimic a lot of time spent in game render phase.
             int64_t sleepTime = static_cast<int64_t>(frameState.predictedDisplayPeriod * renderBlockPercentage);

--- a/src/conformance/conformance_test/test_LayerComposition.cpp
+++ b/src/conformance/conformance_test/test_LayerComposition.cpp
@@ -649,8 +649,10 @@ namespace Conformance
         SimpleProjectionLayerHelper simpleProjectionLayerHelper(compositionHelper);
 
         auto updateLayers = [&](const XrFrameState& frameState) {
-            simpleProjectionLayerHelper.UpdateProjectionLayer(frameState);
-            std::vector<XrCompositionLayerBaseHeader*> layers{simpleProjectionLayerHelper.GetProjectionLayer()};
+            std::vector<XrCompositionLayerBaseHeader*> layers;
+            if (XrCompositionLayerBaseHeader* projLayer = simpleProjectionLayerHelper.TryGetUpdatedProjectionLayer(frameState)) {
+                layers.push_back(projLayer);
+            }
             return interactiveLayerManager.EndFrame(frameState, layers);
         };
 
@@ -743,8 +745,10 @@ namespace Conformance
                     }
                 }
             }
-            simpleProjectionLayerHelper.UpdateProjectionLayer(frameState, cubes);
-            std::vector<XrCompositionLayerBaseHeader*> layers{simpleProjectionLayerHelper.GetProjectionLayer()};
+            std::vector<XrCompositionLayerBaseHeader*> layers;
+            if (XrCompositionLayerBaseHeader* projLayer = simpleProjectionLayerHelper.TryGetUpdatedProjectionLayer(frameState, cubes)) {
+                layers.push_back(projLayer);
+            }
             return interactiveLayerManager.EndFrame(frameState, layers);
         };
 

--- a/src/conformance/framework/composition_utils.cpp
+++ b/src/conformance/framework/composition_utils.cpp
@@ -480,17 +480,12 @@ namespace Conformance
         }
     }
 
-    XrCompositionLayerBaseHeader* SimpleProjectionLayerHelper::GetProjectionLayer() const
-    {
-        return reinterpret_cast<XrCompositionLayerBaseHeader*>(m_projLayer);
-    }
-
-    void SimpleProjectionLayerHelper::UpdateProjectionLayer(const XrFrameState& frameState, const std::vector<Cube> cubes)
+    XrCompositionLayerBaseHeader* SimpleProjectionLayerHelper::TryGetUpdatedProjectionLayer(const XrFrameState& frameState,
+                                                                                            const std::vector<Cube> cubes)
     {
         auto viewData = m_compositionHelper.LocateViews(m_localSpace, frameState.predictedDisplayTime);
         const auto& viewState = std::get<XrViewState>(viewData);
 
-        std::vector<XrCompositionLayerBaseHeader*> layers;
         if (viewState.viewStateFlags & XR_VIEW_STATE_POSITION_VALID_BIT && viewState.viewStateFlags & XR_VIEW_STATE_ORIENTATION_VALID_BIT) {
             const auto& views = std::get<std::vector<XrView>>(viewData);
 
@@ -505,6 +500,12 @@ namespace Conformance
                         GetGlobalData().graphicsPlugin->RenderView(m_projLayer->views[view], swapchainImage, format, cubes);
                     });
             }
+
+            return reinterpret_cast<XrCompositionLayerBaseHeader*>(m_projLayer);
+        }
+        else {
+            // Cannot use the projection layer because the swapchains it uses may not have ever been acquired and released.
+            return nullptr;
         }
     }
 }  // namespace Conformance

--- a/src/conformance/framework/composition_utils.h
+++ b/src/conformance/framework/composition_utils.h
@@ -154,10 +154,10 @@ namespace Conformance
     {
     public:
         SimpleProjectionLayerHelper(CompositionHelper& compositionHelper);
-        XrCompositionLayerBaseHeader* GetProjectionLayer() const;
-        void UpdateProjectionLayer(const XrFrameState& frameState,
-                                   const std::vector<Cube> cubes = {Cube::Make({-1, 0, -2}), Cube::Make({1, 0, -2}),
-                                                                    Cube::Make({0, -1, -2}), Cube::Make({0, 1, -2})});
+        XrCompositionLayerBaseHeader* TryGetUpdatedProjectionLayer(const XrFrameState& frameState,
+                                                                   const std::vector<Cube> cubes = {
+                                                                       Cube::Make({-1, 0, -2}), Cube::Make({1, 0, -2}),
+                                                                       Cube::Make({0, -1, -2}), Cube::Make({0, 1, -2})});
         XrSpace GetLocalSpace() const
         {
             return m_localSpace;


### PR DESCRIPTION
If xrLocateViews returns no valid position or orientation (tracking system isn't tracking yet), `SimpleProjectionLayerHelper` would still return the layer for composition even though the swapchain it uses would never have been acquired/released which causes a conformance runtime to return `XR_ERROR_LAYER_INVALID`. To solve this, I changed it so the helper only provides the layer when there is a tracked pose.