### PR TITLE
Fix Android building

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -141,6 +141,13 @@ cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ../..
 make
 ```
 
+### Android
+
+```sh
+cd src/conformance
+./gradlew clean && ./gradlew build
+```
+
 ## Running the HELLO_XR sample
 
 ### OpenXR runtime installation

--- a/src/conformance/build.gradle
+++ b/src/conformance/build.gradle
@@ -42,7 +42,6 @@ android {
         externalNativeBuild {
             cmake {
                 arguments '-DANDROID_STL=c++_shared',
-                        '-DBUILD_API_LAYERS=ON',
                         '-DBUILD_TESTS=OFF',
                         '-DBUILD_LOADER=ON',
                         '-DBUILD_CONFORMANCE_TESTS=ON',

--- a/src/version.gradle
+++ b/src/version.gradle
@@ -1,0 +1,57 @@
+// Copyright (c) 2020-2022, The Khronos Group Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+class OpenXRVersion {
+    public int major;
+    public int minor;
+    public int patch;
+
+    /// Returns a version code for Android usage.
+    int getVersionCode() {
+        if (major != 1 || minor != 0) {
+            throw new RuntimeException("Version code mapping needs update for OpenXR 1.1+")
+        }
+        patch - 19
+    }
+
+    @Override
+    String toString() {
+        "${major}.${minor}.${patch}"
+    }
+
+    /**
+     * Parses the registry (as a text file) or the openxr.h header to get the version.
+     * @param project Gradle project
+     * @param fn registry or header filename
+     * @return version parsed
+     */
+    static def parseOpenXRVersionFile(Project project, def fn) {
+        def matches = project.file(fn).readLines().find {
+            it.contains('XR_CURRENT_API_VERSION')
+        } =~ ~/\(([^\)]+)\)/
+        def components = matches[0][1].split(',').collect { it.replace(' ', '').trim() }
+        def version = new OpenXRVersion()
+        version.major = Integer.parseInt(components[0])
+        version.minor = Integer.parseInt(components[1])
+        version.patch = Integer.parseInt(components[2])
+        version
+    }
+}
+
+class OpenXRVersionPlugin implements Plugin<Project> {
+
+    void apply(Project project) {
+        project.ext.versionOpenXR = OpenXRVersion.parseOpenXRVersionFile(project,
+                "${project.repoRoot}/specification/registry/xr.xml")
+        project.group = "org.khronos.openxr"
+
+        if (project.file("${project.repoRoot}/SNAPSHOT").exists()) {
+            project.ext.versionQualifier = "-SNAPSHOT"
+        } else {
+            project.ext.versionQualifier = ""
+        }
+    }
+}
+
+apply plugin: OpenXRVersionPlugin


### PR DESCRIPTION
1. Copying `version.gradle` from `OpenXR-SDK-Source`.
2. Removing `-DBUILD_API_LAYERS=ON'` at Android's `build.gradle` and leaving api_layers enabling logic to `CMakeLists.txt` only.
3. Adding Android building tutorial.

Fix https://github.com/KhronosGroup/OpenXR-CTS/issues/31.