### PR TITLE
conformance: Bump AGP to 7.0.4

### DIFF
--- a/changes/conformance/pr.43.gh.OpenXR-CTS.md
+++ b/changes/conformance/pr.43.gh.OpenXR-CTS.md
@@ -1,0 +1,1 @@
+conformance: Bump AGP to 7.0.4 to fix building on M1 device 

--- a/src/conformance/build.gradle
+++ b/src/conformance/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:7.0.4'
     }
 }
 

--- a/src/conformance/gradle/wrapper/gradle-wrapper.properties
+++ b/src/conformance/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
It will help to fix building on M1 device.