### PR TITLE
Fix incorrect handling of xrCreateSwapchainAndroidSurfaceKHR in template_gen_dispatch.cpp

### DIFF
--- a/src/scripts/template_gen_dispatch.cpp
+++ b/src/scripts/template_gen_dispatch.cpp
@@ -110,6 +110,17 @@
     }
 //#         endif
 
+//## xrCreateSwapchainAndroidSurfaceKHR is a special case because
+//## this is a create command but returned swapchain is not the last parameter.
+//#         set is_create_swapchain_android_surface = ("xrCreateSwapchainAndroidSurfaceKHR" == cur_cmd.name)
+//#         if is_create_swapchain_android_surface
+    if (XR_SUCCEEDED(result)) {
+//#             set out_handle_param_name = cur_cmd.params[-2].name
+        HandleState* const parentHandleState = GetHandleState(HandleStateKey{HandleToInt(/*{ first_handle_name }*/), XR_OBJECT_TYPE_SESSION});
+        RegisterHandleState(parentHandleState->CloneForChild(HandleToInt(* /*{ out_handle_param_name }*/), XR_OBJECT_TYPE_SWAPCHAIN));
+    }
+//#         endif
+
 //## If this is a xrQuerySpacesFB, we have to create an entry in
 //## the appropriate unordered_map pointing to the correct dispatch table for
 //## the newly created objects.


### PR DESCRIPTION
There is a bug in template_gen_dispatch.cpp that causes an error when destroying swapchain created by xrCreateSwapchainAndroidSurfaceKHR.

Here is an example. On Quest3, xrCreateSwapchainAndroidSurfaceKHR returns XR_SUCCESS, but xrDestroySwapchain returns XR_ERROR_HANDLE_INVALID.

```
CHECK(xrCreateSwapchainAndroidSurfaceKHR(session, &createInfo, &swapchain, &surface) == XR_SUCCESS);
CHECK(xrDestroySwapchain(swapchain) == XR_SUCCESS);
```

Check the log, there is an error message from conformance layer.

```
XrApiLayer_runtime_conformance: ERROR: Conformance Layer: Unknown handle used, created by unrecognized API call? Message = Encountered unknown XR_OBJECT_TYPE_SWAPCHAIN handle with value 519582891248
OpenXR_Conformance:   CHECK( xrDestroySwapchain(swapchain) == XR_SUCCESS )
OpenXR_Conformance: with expansion:
OpenXR_Conformance:   XR_ERROR_HANDLE_INVALID == XR_SUCCESS
```

template_gen_dispatch.cpp identifies a command as a create command if the function name includes "xrCreate" and the last parameter is a handle. xrCreateSwapchainAndroidSurfaceKHR is a special case because this is a create command but returned swapchain is not the last parameter. So template_gen_dispatch.cpp doesn't handle this command correctly.

Modify template_gen_dispatch.cpp, register handle state for swapchain created by xrCreateSwapchainAndroidSurfaceKHR.
