### PR TITLE
Install `XrApiLayer_conformance_test_layer.json`

### DIFF
--- a/changes/conformance/pr.100.gh.OpenXR-CTS.md
+++ b/changes/conformance/pr.100.gh.OpenXR-CTS.md
@@ -1,0 +1,1 @@
+Fix: Install manifest for conformance test layer

--- a/src/conformance/conformance_test/CMakeLists.txt
+++ b/src/conformance/conformance_test/CMakeLists.txt
@@ -239,6 +239,11 @@ set_target_properties(
 )
 
 install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/XrApiLayer_conformance_test_layer.json
+    DESTINATION conformance
+)
+
+install(
     TARGETS conformance_test
     LIBRARY DESTINATION conformance
     ARCHIVE DESTINATION conformance


### PR DESCRIPTION
This is missing from at least the Openxr-cts-x64 bundle, and appears to not be installed by CMake

Taken the same approach as https://github.com/KhronosGroup/OpenXR-CTS/blob/devel/src/conformance/conformance_layer/CMakeLists.txt

Without this, `validApiLayer` fails on all runtimes when using a prebuild CTS bundle.