### PR TITLE
Fix conformance_cli.exe being built to Debug/ or Release/ folder when running with msvc

### DIFF
--- a/src/conformance/conformance_cli/CMakeLists.txt
+++ b/src/conformance/conformance_cli/CMakeLists.txt
@@ -49,6 +49,14 @@ file(
 
 add_executable(conformance_cli ${LOCAL_SOURCE} ${LOCAL_HEADERS})
 
+set_target_properties(
+    conformance_cli
+    PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY $<TARGET_PROPERTY:conformance_cli,BINARY_DIR>
+        LIBRARY_OUTPUT_DIRECTORY $<TARGET_PROPERTY:conformance_cli,BINARY_DIR>
+        ARCHIVE_OUTPUT_DIRECTORY $<TARGET_PROPERTY:conformance_cli,BINARY_DIR>
+)
+
 source_group("Headers" FILES ${LOCAL_HEADERS})
 
 add_dependencies(conformance_cli conformance_test)


### PR DESCRIPTION
When using MSVC, conformance_cli.exe was being placed in a different folder to the assets (conformance_cli/Debug, /Release) which meant that there would need to be an extra step of specifying the correct working directory or moving the exe to the right place. This PR prevents it from being placed in a Debug/Release folder.