### PR TITLE
Add hint for 'git lfs fetch'

### DIFF
--- a/changes/conformance/pr.103.gh.OpenXR-CTS.md
+++ b/changes/conformance/pr.103.gh.OpenXR-CTS.md
@@ -1,0 +1,1 @@
+conformance: Add hint for 'git lfs fetch' for cmake

--- a/src/conformance/conformance_test/CMakeLists.txt
+++ b/src/conformance/conformance_test/CMakeLists.txt
@@ -51,7 +51,7 @@ file(STRINGS gltf_examples/VertexColorTest.glb LFS_CHECK_STRINGS)
 if(LFS_CHECK_STRINGS MATCHES "https://git-lfs[.]github[.]com/spec/v1")
     message(
         FATAL_ERROR
-            "Found a git-lfs pointer file instead of the binary file that should replace it. Please install git-lfs, run 'git lfs install', and 'git lfs checkout'"
+            "Found a git-lfs pointer file instead of the binary file that should replace it. Please install git-lfs, run 'git lfs install', 'git lfs checkout', and 'git lfs fetch'"
     )
 endif()
 


### PR DESCRIPTION
It can be used to fetch lfs files if I install git-lfs after checkout.