### PR TITLE
Avoid potential format conversion when use vkCmdBlitImage to copy image with the same format

### DIFF
--- a/src/conformance/framework/RGBAImage.cpp
+++ b/src/conformance/framework/RGBAImage.cpp
@@ -328,6 +328,7 @@ namespace Conformance
             pixel.Channels.G = (uint8_t)(ColorUtils::ToSRGB((double)pixel.Channels.G / 255.0) * 255.0);
             pixel.Channels.B = (uint8_t)(ColorUtils::ToSRGB((double)pixel.Channels.B / 255.0) * 255.0);
         }
+        isSrgb = true;
     }
 
     void RGBAImage::CopyWithStride(uint8_t* data, uint32_t rowPitch, uint32_t offset) const

--- a/src/conformance/framework/graphics_plugin_vulkan.cpp
+++ b/src/conformance/framework/graphics_plugin_vulkan.cpp
@@ -1927,14 +1927,26 @@ namespace Conformance
         imgBarrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, arraySlice, 1};
         vkCmdPipelineBarrier(m_cmdBuffer.buf, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1,
                              &imgBarrier);
-
-        // Blit staging -> swapchain
-        VkImageBlit blit = {{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1},
-                            {{0, 0, 0}, {(int32_t)w, (int32_t)h, 1}},
-                            {VK_IMAGE_ASPECT_COLOR_BIT, 0, arraySlice, 1},
-                            {{0, 0, 0}, {(int32_t)w, (int32_t)h, 1}}};
-        vkCmdBlitImage(m_cmdBuffer.buf, stagingImage, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, swapchainImageVk->image,
-                       VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit, VK_FILTER_NEAREST);
+        
+        if (image.isSrgb) {
+            // copy staging -> swapchain
+            VkImageCopy copyRegion = {{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1},
+                                      {0, 0, 0},
+                                      {VK_IMAGE_ASPECT_COLOR_BIT, 0, arraySlice, 1},
+                                      {0, 0, 0},
+                                      {(uint32_t)w, (uint32_t)h, 1}}; 
+            vkCmdCopyImage(m_cmdBuffer.buf, stagingImage, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, swapchainImageVk->image,
+                           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copyRegion); 
+        }
+        else {
+            // Blit staging -> swapchain
+            VkImageBlit blit = {{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1},
+                                {{0, 0, 0}, {(int32_t)w, (int32_t)h, 1}},
+                                {VK_IMAGE_ASPECT_COLOR_BIT, 0, arraySlice, 1},
+                                {{0, 0, 0}, {(int32_t)w, (int32_t)h, 1}}};
+            vkCmdBlitImage(m_cmdBuffer.buf, stagingImage, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, swapchainImageVk->image,
+                           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit, VK_FILTER_NEAREST);
+        }
 
         // Switch the destination image from TRANSFER_DST_OPTIMAL -> COLOR_ATTACHMENT_OPTIMAL
         //


### PR DESCRIPTION
I found that some test cases, which all use `CompositionHelper::CreateStaticSwapchainImage` to create sRGB image, may have different results when running on different devices. The known issue [#64](https://github.com/KhronosGroup/OpenXR-CTS/issues/64) is typically.

An SRGB swapchain is being created with images that have a UNORM format due to platform limitations, referring to [monado#1357](https://gitlab.freedesktop.org/monado/monado/-/merge_requests/1357). Deep seeking the CTS code, the `vkCmdBlitImage` is used to copy image regions with potentially performing format conversion even though the images have a same format.

I suggest that use `vkCmdCopyImage` instead of `vkCmdBlitImage` when the src and dst images have a same format(sRGB) in the CTS code. And I verified this change can fix issue [#64](https://github.com/KhronosGroup/OpenXR-CTS/issues/64).