### PR TITLE
Fix the conformance layer warning in the XR_MND_headless test case

### DIFF
--- a/src/conformance/conformance_test/test_XR_MND_headless.cpp
+++ b/src/conformance/conformance_test/test_XR_MND_headless.cpp
@@ -39,6 +39,8 @@ namespace Conformance
         }
 
         AutoBasicSession session(AutoBasicSession::createSession | AutoBasicSession::skipGraphics);
+        FrameIterator frameIterator(&session);
+        frameIterator.RunToSessionState(XR_SESSION_STATE_READY);
 
         SECTION("xrEnumerateSwapchainFormats should return XR_SUCCESS but zero formats.")
         {
@@ -62,6 +64,7 @@ namespace Conformance
 
         // To do: call input and tracking functions here.
         REQUIRE_RESULT_UNQUALIFIED_SUCCESS(xrRequestExitSession(session));
+        frameIterator.RunToSessionState(XR_SESSION_STATE_STOPPING);
         REQUIRE_RESULT_UNQUALIFIED_SUCCESS(xrEndSession(session));
     }
 }  // namespace Conformance

--- a/src/conformance/framework/conformance_utils.cpp
+++ b/src/conformance/framework/conformance_utils.cpp
@@ -1025,7 +1025,14 @@ namespace Conformance
             case XR_SESSION_STATE_FOCUSED: {
                 // In these states we need to submit frames. Otherwise the runtime won't
                 // necessarily move us from synchronized to visible or focused.
-                REQUIRE(SubmitFrame() == RunResult::Success);
+                // XR_MND_headless:
+                // In a headless session, the session state proceeds to XR_SESSION_STATE_SYNCHRONIZED,
+                // then XR_SESSION_STATE_VISIBLE and XR_SESSION_STATE_FOCUSED, after the call to
+                // xrBeginSession. The application does not need to call xrWaitFrame, xrBeginFrame, or
+                // xrEndFrame, unlike with non-headless sessions.
+                if (!autoBasicSession->IsSkippingGraphics()) {
+                    REQUIRE(SubmitFrame() == RunResult::Success);
+                }
 
                 // Just keep going. We haven't reached the target state yet.
                 break;

--- a/src/conformance/framework/conformance_utils.h
+++ b/src/conformance/framework/conformance_utils.h
@@ -686,6 +686,11 @@ namespace Conformance
             return session != XR_NULL_HANDLE;
         }
 
+        bool IsSkippingGraphics() const
+        {
+            return (optionFlags & skipGraphics) != 0;
+        }
+
     private:
         int optionFlags{0};  //< Enum OptionFlags
 


### PR DESCRIPTION
When running "XR_MND_headless" test case, CTS shows a conformance layer warning.

```
/builds/openxr/openxr/src/conformance/conformance_test/test_XR_MND_headless.cpp:25
...............................................................................
/builds/openxr/openxr/src/conformance/framework/conformance_utils.cpp:325: warning:
  Conformance layer warning: xrEndSession: Expected
  XR_ERROR_SESSION_NOT_STOPPING when last known session state was
  XR_SESSION_STATE_UNKNOWN
```

This test case calls `xrEndSession`, then conformance layer calls `ConformanceHooks::xrEndSession`. This function checks `customSessionState->sessionState` and shows a warning when the value is not XR_SESSION_STATE_STOPPING. In this test case, `customSessionState->sessionState` is not updated and keeps XR_SESSION_STATE_UNKNOWN.

This change adds a function `runToSessionState` in this test case. Ensure the custom session state is changed to XR_SESSION_STATE_STOPPING before calling `xrEndSession`. Some codes are copied from test_SessionState.cpp.

I had considered modifying and using `FrameIterator::RunToSessionState`. In a headless session, app does not need to submit frames. I think using `FrameIterator` in a headless session may be confusing.