### PR TITLE
Add Khronos copyright for XR_FB_composition_layer_image_layout tests

### DIFF
--- a/src/conformance/conformance_test/composition_examples/image_layout_flags_0.jpg.license
+++ b/src/conformance/conformance_test/composition_examples/image_layout_flags_0.jpg.license
@@ -1,3 +1,4 @@
+SPDX-FileCopyrightText: 2025 The Khronos Group Inc.
 SPDX-FileCopyrightText: Qualcomm Technologies, Inc. and/or its subsidiaries.
 
 SPDX-License-Identifier: Apache-2.0

--- a/src/conformance/conformance_test/composition_examples/image_layout_flags_1.jpg.license
+++ b/src/conformance/conformance_test/composition_examples/image_layout_flags_1.jpg.license
@@ -1,3 +1,4 @@
+SPDX-FileCopyrightText: 2025 The Khronos Group Inc.
 SPDX-FileCopyrightText: Qualcomm Technologies, Inc. and/or its subsidiaries.
 
 SPDX-License-Identifier: Apache-2.0

--- a/src/conformance/conformance_test/composition_examples/image_layout_without_extension.jpg.license
+++ b/src/conformance/conformance_test/composition_examples/image_layout_without_extension.jpg.license
@@ -1,3 +1,4 @@
+SPDX-FileCopyrightText: 2025 The Khronos Group Inc.
 SPDX-FileCopyrightText: Qualcomm Technologies, Inc. and/or its subsidiaries.
 
 SPDX-License-Identifier: Apache-2.0

--- a/src/conformance/conformance_test/test_XR_FB_composition_layer_image_layout.cpp
+++ b/src/conformance/conformance_test/test_XR_FB_composition_layer_image_layout.cpp
@@ -1,3 +1,4 @@
+// Copyright (c) 2025 The Khronos Group Inc.
 // Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 //
 // SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Sorry for the lack of the Khronos copyright in https://github.com/KhronosGroup/OpenXR-CTS/pull/111. This PR adds the missing Khronos copyright.

This is a minor change. I'm not sure if a changelog fragment is needed, but I can add one if required.