### PR TITLE
Extended the Quad Occlusion test with Alpha Blending and Additive Leaning  

### DIFF
--- a/src/conformance/conformance_test/composition_examples/quad_occlusion_additive_leaning.png
+++ b/src/conformance/conformance_test/composition_examples/quad_occlusion_additive_leaning.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb26fbaff5ccc34706ab5450757cd13bb80cced64f64b4446c321aad7d916523
+size 20983

--- a/src/conformance/conformance_test/composition_examples/quad_occlusion_additive_leaning.png.license
+++ b/src/conformance/conformance_test/composition_examples/quad_occlusion_additive_leaning.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2019-2025 The Khronos Group Inc.
+
+SPDX-License-Identifier: Apache-2.0

--- a/src/conformance/conformance_test/composition_examples/quad_occlusion_alpha_blending.png
+++ b/src/conformance/conformance_test/composition_examples/quad_occlusion_alpha_blending.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0ecfb8f591ff6c7e617105256b2bcd05434b53e5dd219fa36804b350a668176
+size 3044

--- a/src/conformance/conformance_test/composition_examples/quad_occlusion_alpha_blending.png.license
+++ b/src/conformance/conformance_test/composition_examples/quad_occlusion_alpha_blending.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2019-2025 The Khronos Group Inc.
+
+SPDX-License-Identifier: Apache-2.0

--- a/src/conformance/conformance_test/composition_examples/quad_occlusion_opaque.png
+++ b/src/conformance/conformance_test/composition_examples/quad_occlusion_opaque.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14c6ba2bc52a13dcef0adbb2fee2c1170cf275b817cc0a8a81b178a695269612
+size 49254

--- a/src/conformance/conformance_test/composition_examples/quad_occlusion_opaque.png.license
+++ b/src/conformance/conformance_test/composition_examples/quad_occlusion_opaque.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2019-2025 The Khronos Group Inc.
+
+SPDX-License-Identifier: Apache-2.0

--- a/src/conformance/conformance_test/test_LayerComposition.cpp
+++ b/src/conformance/conformance_test/test_LayerComposition.cpp
@@ -57,6 +57,11 @@ namespace Conformance
             depthInfo->subImage = subImage;
             *nextPtr = depthInfo;
         }
+        std::string GetImageName(std::string imageName){
+            std::transform(imageName.begin(), imageName.end(), imageName.begin(), ::tolower);
+            std::replace(imageName.begin(), imageName.end(), ' ', '_');
+            return imageName;
+        }
     }  // namespace
 
     using namespace openxr::math_operators;
@@ -71,56 +76,59 @@ namespace Conformance
         if (!globalData.IsUsingGraphicsPlugin()) {
             SKIP("Cannot test QuadOcclusion without a graphics plugin");
         }
-
-        for (std::string occlusion_type : {"Opaque", "alpha-blending", "additive-leaning"}) {
-            CompositionHelper compositionHelper(("Quad Occlusion - " + occlusion_type).c_str());
-            InteractiveLayerManager interactiveLayerManager(
-                compositionHelper, "quad_occlusion.png",
-                "This test includes a blue and green quad at Z=-2 with opposite rotations on Y axis forming X. The green quad should be"
-                " fully visible due to painter's algorithm. A red quad is facing away and should not be visible."
-                "The test additionally covers standard alpha-blending behavior as well as additive-leaning blending.");
-            XrSession session = compositionHelper.GetSession();
-            InteractionManager& interactionManager = compositionHelper.GetInteractionManager();
-            interactionManager.AttachActionSets();
-            compositionHelper.BeginSession();
-            XrColor4f Green = Colors::Green;
-            XrColor4f Blue = Colors::Blue;
-            XrColor4f Red = Colors::Red;
-            if (occlusion_type != "Opaque") {
-                Green = {0, 1, 0, 0.5f};  // SemiTransparent Green
+ 
+        for (std::string occlusion_type : {"Opaque", "Alpha Blending", "Additive Leaning"}) {
+            DYNAMIC_SECTION(("Quad Occlusion" + occlusion_type).c_str())
+            {
+                CompositionHelper compositionHelper(("Quad Occlusion " + occlusion_type).c_str());
+                InteractiveLayerManager interactiveLayerManager(
+                    compositionHelper, ("quad_occlusion_" + GetImageName(occlusion_type) + ".png").c_str(),
+                    "This test includes a blue and green quad at Z=-2 with opposite rotations on Y axis forming X. The green quad should be"
+                    " fully visible due to painter's algorithm. A red quad is facing away and should not be visible."
+                    "The test additionally covers standard alpha-blending behavior as well as additive-leaning blending.");
+                XrSession session = compositionHelper.GetSession();
+                InteractionManager& interactionManager = compositionHelper.GetInteractionManager();
+                interactionManager.AttachActionSets();
+                compositionHelper.BeginSession();
+                XrColor4f Green = Colors::Green;
+                XrColor4f Blue = Colors::Blue;
+                XrColor4f Red = Colors::Red;
+                if (occlusion_type != "Opaque") {
+                    Green = {0, 1, 0, 0.5f};  // SemiTransparent Green
+                }
+ 
+                const XrSwapchain greenSwapchain = compositionHelper.CreateStaticSwapchainSolidColor(Green);
+                const XrSwapchain blueSwapchain = compositionHelper.CreateStaticSwapchainSolidColor(Blue);
+                const XrSwapchain redSwapchain = compositionHelper.CreateStaticSwapchainSolidColor(Red);
+ 
+                const XrSpace viewSpace = compositionHelper.CreateReferenceSpace(XR_REFERENCE_SPACE_TYPE_VIEW);
+ 
+                const XrQuaternionf blueRot = Quat::FromAxisAngle({0, 1, 0}, DegToRad(-45));
+                const XrQuaternionf greenRot = Quat::FromAxisAngle({0, 1, 0}, DegToRad(45));
+                const XrQuaternionf redRot = Quat::FromAxisAngle({0, 1, 0}, DegToRad(180));
+ 
+                auto blueQuad = compositionHelper.CreateQuadLayer(blueSwapchain, viewSpace, 1.0f, XrPosef{blueRot, {0, 0, -2}});
+ 
+                interactiveLayerManager.AddLayer(blueQuad);
+ 
+                // Each quad is rotated on Y axis by 45 degrees to form an X.
+                // Green is added second so it should draw over the blue quad.
+                auto greenQuad = compositionHelper.CreateQuadLayer(greenSwapchain, viewSpace, 1.0f, XrPosef{greenRot, {0, 0, -2}});
+ 
+                if (occlusion_type != "Opaque") {
+                    greenQuad->layerFlags |= XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
+                }
+ 
+                if (occlusion_type == "Alpha Blending") {
+                    greenQuad->layerFlags |= XR_COMPOSITION_LAYER_UNPREMULTIPLIED_ALPHA_BIT;
+                }
+                interactiveLayerManager.AddLayer(greenQuad);
+ 
+                // Red quad is rotated away from the viewer and should not be visible.
+                interactiveLayerManager.AddLayer(compositionHelper.CreateQuadLayer(redSwapchain, viewSpace, 1.0f, XrPosef{redRot, {0, 0, -1}}));
+ 
+                RenderLoop(session, [&](const XrFrameState& frameState) { return interactiveLayerManager.EndFrame(frameState); }).Loop();
             }
-
-            const XrSwapchain greenSwapchain = compositionHelper.CreateStaticSwapchainSolidColor(Green);
-            const XrSwapchain blueSwapchain = compositionHelper.CreateStaticSwapchainSolidColor(Blue);
-            const XrSwapchain redSwapchain = compositionHelper.CreateStaticSwapchainSolidColor(Red);
-
-            const XrSpace viewSpace = compositionHelper.CreateReferenceSpace(XR_REFERENCE_SPACE_TYPE_VIEW);
-
-            const XrQuaternionf blueRot = Quat::FromAxisAngle({0, 1, 0}, DegToRad(-45));
-            const XrQuaternionf greenRot = Quat::FromAxisAngle({0, 1, 0}, DegToRad(45));
-            const XrQuaternionf redRot = Quat::FromAxisAngle({0, 1, 0}, DegToRad(180));
-
-            auto blueQuad = compositionHelper.CreateQuadLayer(blueSwapchain, viewSpace, 1.0f, XrPosef{blueRot, {0, 0, -2}});
-
-            interactiveLayerManager.AddLayer(blueQuad);
-
-            // Each quad is rotated on Y axis by 45 degrees to form an X.
-            // Green is added second so it should draw over the blue quad.
-            auto greenQuad = compositionHelper.CreateQuadLayer(greenSwapchain, viewSpace, 1.0f, XrPosef{greenRot, {0, 0, -2}});
-
-            if (occlusion_type != "Opaque") {
-                greenQuad->layerFlags |= XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
-            }
-
-            if (occlusion_type == "alpha-blending") {
-                greenQuad->layerFlags |= XR_COMPOSITION_LAYER_UNPREMULTIPLIED_ALPHA_BIT;
-            }
-            interactiveLayerManager.AddLayer(greenQuad);
-
-            // Red quad is rotated away from the viewer and should not be visible.
-            interactiveLayerManager.AddLayer(compositionHelper.CreateQuadLayer(redSwapchain, viewSpace, 1.0f, XrPosef{redRot, {0, 0, -1}}));
-
-            RenderLoop(session, [&](const XrFrameState& frameState) { return interactiveLayerManager.EndFrame(frameState); }).Loop();
         }
     }
 

--- a/src/conformance/conformance_test/test_LayerComposition.cpp
+++ b/src/conformance/conformance_test/test_LayerComposition.cpp
@@ -64,6 +64,7 @@ namespace Conformance
     // Purpose: Verify behavior of quad visibility and occlusion with the expectation that:
     // 1. Quads render with painters algo.
     // 2. Quads which are facing away are not visible.
+    // 3. Quads using alpha or additive blending blend correctly as expected.
     TEST_CASE("QuadOcclusion", "[composition][interactive]")
     {
         GlobalData& globalData = GetGlobalData();
@@ -71,33 +72,56 @@ namespace Conformance
             SKIP("Cannot test QuadOcclusion without a graphics plugin");
         }
 
-        CompositionHelper compositionHelper("Quad Occlusion");
-        InteractiveLayerManager interactiveLayerManager(
-            compositionHelper, "quad_occlusion.png",
-            "This test includes a blue and green quad at Z=-2 with opposite rotations on Y axis forming X. The green quad should be"
-            " fully visible due to painter's algorithm. A red quad is facing away and should not be visible.");
-        XrSession session = compositionHelper.GetSession();
-        InteractionManager& interactionManager = compositionHelper.GetInteractionManager();
-        interactionManager.AttachActionSets();
-        compositionHelper.BeginSession();
+        for (std::string occlusion_type : {"Opaque", "alpha-blending", "additive-leaning"}) {
+            CompositionHelper compositionHelper(("Quad Occlusion - " + occlusion_type).c_str());
+            InteractiveLayerManager interactiveLayerManager(
+                compositionHelper, "quad_occlusion.png",
+                "This test includes a blue and green quad at Z=-2 with opposite rotations on Y axis forming X. The green quad should be"
+                " fully visible due to painter's algorithm. A red quad is facing away and should not be visible."
+                "The test additionally covers standard alpha-blending behavior as well as additive-leaning blending.");
+            XrSession session = compositionHelper.GetSession();
+            InteractionManager& interactionManager = compositionHelper.GetInteractionManager();
+            interactionManager.AttachActionSets();
+            compositionHelper.BeginSession();
+            XrColor4f Green = Colors::Green;
+            XrColor4f Blue = Colors::Blue;
+            XrColor4f Red = Colors::Red;
+            if (occlusion_type != "Opaque") {
+                Green = {0, 1, 0, 0.5f};  // SemiTransparent Green
+            }
 
-        const XrSwapchain greenSwapchain = compositionHelper.CreateStaticSwapchainSolidColor(Colors::Green);
-        const XrSwapchain blueSwapchain = compositionHelper.CreateStaticSwapchainSolidColor(Colors::Blue);
-        const XrSwapchain redSwapchain = compositionHelper.CreateStaticSwapchainSolidColor(Colors::Red);
+            const XrSwapchain greenSwapchain = compositionHelper.CreateStaticSwapchainSolidColor(Green);
+            const XrSwapchain blueSwapchain = compositionHelper.CreateStaticSwapchainSolidColor(Blue);
+            const XrSwapchain redSwapchain = compositionHelper.CreateStaticSwapchainSolidColor(Red);
 
-        const XrSpace viewSpace = compositionHelper.CreateReferenceSpace(XR_REFERENCE_SPACE_TYPE_VIEW);
+            const XrSpace viewSpace = compositionHelper.CreateReferenceSpace(XR_REFERENCE_SPACE_TYPE_VIEW);
 
-        // Each quad is rotated on Y axis by 45 degrees to form an X.
-        // Green is added second so it should draw over the blue quad.
-        const XrQuaternionf blueRot = Quat::FromAxisAngle({0, 1, 0}, DegToRad(-45));
-        interactiveLayerManager.AddLayer(compositionHelper.CreateQuadLayer(blueSwapchain, viewSpace, 1.0f, XrPosef{blueRot, {0, 0, -2}}));
-        const XrQuaternionf greenRot = Quat::FromAxisAngle({0, 1, 0}, DegToRad(45));
-        interactiveLayerManager.AddLayer(compositionHelper.CreateQuadLayer(greenSwapchain, viewSpace, 1.0f, XrPosef{greenRot, {0, 0, -2}}));
-        // Red quad is rotated away from the viewer and should not be visible.
-        const XrQuaternionf redRot = Quat::FromAxisAngle({0, 1, 0}, DegToRad(180));
-        interactiveLayerManager.AddLayer(compositionHelper.CreateQuadLayer(redSwapchain, viewSpace, 1.0f, XrPosef{redRot, {0, 0, -1}}));
+            const XrQuaternionf blueRot = Quat::FromAxisAngle({0, 1, 0}, DegToRad(-45));
+            const XrQuaternionf greenRot = Quat::FromAxisAngle({0, 1, 0}, DegToRad(45));
+            const XrQuaternionf redRot = Quat::FromAxisAngle({0, 1, 0}, DegToRad(180));
 
-        RenderLoop(session, [&](const XrFrameState& frameState) { return interactiveLayerManager.EndFrame(frameState); }).Loop();
+            auto blueQuad = compositionHelper.CreateQuadLayer(blueSwapchain, viewSpace, 1.0f, XrPosef{blueRot, {0, 0, -2}});
+
+            interactiveLayerManager.AddLayer(blueQuad);
+
+            // Each quad is rotated on Y axis by 45 degrees to form an X.
+            // Green is added second so it should draw over the blue quad.
+            auto greenQuad = compositionHelper.CreateQuadLayer(greenSwapchain, viewSpace, 1.0f, XrPosef{greenRot, {0, 0, -2}});
+
+            if (occlusion_type != "Opaque") {
+                greenQuad->layerFlags |= XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
+            }
+
+            if (occlusion_type == "alpha-blending") {
+                greenQuad->layerFlags |= XR_COMPOSITION_LAYER_UNPREMULTIPLIED_ALPHA_BIT;
+            }
+            interactiveLayerManager.AddLayer(greenQuad);
+
+            // Red quad is rotated away from the viewer and should not be visible.
+            interactiveLayerManager.AddLayer(compositionHelper.CreateQuadLayer(redSwapchain, viewSpace, 1.0f, XrPosef{redRot, {0, 0, -1}}));
+
+            RenderLoop(session, [&](const XrFrameState& frameState) { return interactiveLayerManager.EndFrame(frameState); }).Loop();
+        }
     }
 
     namespace SimpleTestLayers


### PR DESCRIPTION
## Description  
This PR enhances the existing `QuadOcclusion` interactive test in `test_LayerComposition.cpp` to comprehensively validate composition layer blending behavior across different blend modes:  

- **Opaque blending**: Tests standard opaque quad rendering with painter's algorithm  
- **Alpha blending**: Validates `XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT` flag behavior with transparent quads  
- **Additive blending**: Tests additive composition where colors accumulate  

### Changes Made  
- Added test sections for each blend mode using `DYNAMIC_SECTION` to ensure independent execution  
- Maintained existing test structure and interactive validation pattern  

### Testing  
Tested on Monado runtime (Linux) with OpenGL/Vulkan graphics plugin. All blend modes render correctly and can be visually validated by the user.  

### Motivation  
The original `QuadOcclusion` test only validated basic occlusion with opaque quads.